### PR TITLE
Restructure the backports_repo.py script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,19 @@
+python-backports-generate
+=========================
+This repository is a collection of scripts to handle the
+`devel:languages:python:backport`_ repository on the OpenBuildService.
+
+backports_repo.py
+-----------------
+This script will sync the python packages between `openSUSE:Factory`_ and the `devel:languages:python:backport`_ project.
+For Python packages available in `openSUSE:Factory`_, links will be created
+from `openSUSE:Factory`_ to `devel:languages:python:backport`_ . If a package is
+in `devel:languages:python:backport`_ but not in `openSUSE:Factory`_, the package
+will be removed from `devel:languages:python:backport`_ .
+
+There is the `backports_repo.json` configuration file which can handle additional
+links needed. This is useful for extra BuildRequires (like `python-redis` BuildRequires
+`redis` so `redis` needs to be in the `backports_repo.json` configuration file)
+
+.. _`devel:languages:python:backport`: https://build.opensuse.org/project/show/devel:languages:python:backports
+.. _`openSUSE:Factory`: https://build.opensuse.org/project/show/openSUSE:Factory

--- a/backports_repo.py
+++ b/backports_repo.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import argparse
 import concurrent.futures
 import configparser
 import io
@@ -17,28 +18,33 @@ logging.basicConfig(format='%(levelname)s:%(funcName)s:%(message)s',
                     level=logging.DEBUG)
 log = logging.getLogger('backports_repo')
 
-project = "devel:languages:python:backports"
-factory_name = "openSUSE:Factory"
-
-cfg = configparser.ConfigParser()
-cfg.read(os.path.expanduser('~/.config/osc/oscrc'))
-OBS_API = 'https://api.opensuse.org'
-OBS_cfg = cfg[OBS_API]
 MAX_PROCS = 5
 
-# available in python >= 3.5
-pwd_mgr = urllib.request.HTTPPasswordMgrWithPriorAuth()
-pwd_mgr.add_password(realm=None, uri=OBS_API,
-                     user=OBS_cfg['user'],
-                     passwd=OBS_cfg['pass'])
-https_handler = urllib.request.HTTPSHandler(debuglevel=0)
-auth_handler = urllib.request.HTTPBasicAuthHandler(pwd_mgr)
-opener = urllib.request.build_opener(https_handler, auth_handler)
+def _get_osc_config(config_file, config_section):
+    """
+    Get the osc (OpenBuildService command line client) config
+    for the the given config_section
+    """
+    if not os.path.exists(config_file):
+        raise Exception('Config file {} does not exist'.format(config_file))
+    cfg = configparser.ConfigParser()
+    cfg.read(os.path.expanduser('~/.config/osc/oscrc'))
+    return cfg[config_section]
 
-src_URL = "%s/source/{}" % OBS_API
+
+def _get_opener(obs_api, obs_user, obs_password):
+    # available in python >= 3.5
+    pwd_mgr = urllib.request.HTTPPasswordMgrWithPriorAuth()
+    pwd_mgr.add_password(realm=None, uri=obs_api,
+                         user=obs_user,
+                         passwd=obs_password)
+    https_handler = urllib.request.HTTPSHandler(debuglevel=0)
+    auth_handler = urllib.request.HTTPBasicAuthHandler(pwd_mgr)
+    opener = urllib.request.build_opener(https_handler, auth_handler)
+    return opener
 
 
-def project_list(url):
+def project_list(opener, url):
     with opener.open(url, timeout=10) as response:
         assert response.status == 200
         for _, element in etree.iterparse(response):
@@ -63,51 +69,80 @@ def linkpac(pkg, proj_source):
     return ret
 
 
-backports_python = {x for x in project_list(src_URL.format(project))}
-factory_python = {x for x in project_list(src_URL.format(factory_name))
-                  if x.startswith('python')}
-python_itself = {"python-base", "python3-base", "python", "python3",
-                 "python-doc", "python3-doc"}
+def _get_additional_links_from_config():
+    additional_links = set()
+    additional_conf_file = os.path.join(appdirs.user_config_dir(),
+                                        'osc', 'backports_repo.json')
+    # Fall back to in-tree copy
+    if not os.path.exists(additional_conf_file):
+        additional_conf_file = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), 'backports_repo.json')
 
-additional_conf_file = os.path.join(appdirs.user_config_dir(),
-                                    'osc', 'backports_repo.json')
-
-# Fall back to in-tree copy
-if not os.path.exists(additional_conf_file):
-    additional_conf_file = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), 'backports_repo.json')
-
-# extra packages we want there
-additional_links = set()
-if os.path.exists(additional_conf_file):
-    with io.open(additional_conf_file) as conf_f:
-        obj = json.load(conf_f)
-        if 'additional_links' not in obj:
-            raise KeyError(
-                '"additional_links" not found in configuration file %s' %
-                additional_conf_file)
+    # extra packages we want there
+    if os.path.exists(additional_conf_file):
+        with io.open(additional_conf_file) as conf_f:
+            obj = json.load(conf_f)
+            if 'additional_links' not in obj:
+                raise KeyError(
+                    '"additional_links" not found in configuration file %s' %
+                    additional_conf_file)
         additional_links = set(obj['additional_links'])
-
-factory_python = factory_python | additional_links
-factory_python -= {
-    'python-Django',  # prefer python-Django1
-}
+    return additional_links
 
 
-futures = []
-with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_PROCS) as executor:
-    # remove packages not in tumbleweed
-    for package in backports_python - factory_python:
-        futures.append(executor.submit(rdelete, package, project))
+def main(args):
+    osc_cfg = _get_osc_config(os.path.expanduser('~/.config/osc/oscrc'),
+                              args.obs_api)
+    opener = _get_opener(args.obs_api, osc_cfg['user'], osc_cfg['pass'])
+    # packages already in the backports project
+    backports_python = {x for x in project_list(opener, '{}/source/{}'.format(
+        args.obs_api, args.backports_project))}
+    # packages already in the factory project
+    factory_python = {x for x in project_list(opener, '{}/source/{}'.format(
+        args.obs_api, args.factory_project)) if x.startswith('python')}
+    python_itself = {"python-base", "python3-base", "python", "python3",
+                     "python-doc", "python3-doc"}
+    # additional link we want to link from Factory to Backports
+    additional_links = _get_additional_links_from_config()
 
-    # add packages not in yet
-    for package in factory_python - python_itself - backports_python:
-        futures.append(executor.submit(linkpac, package, project))
+    factory_python = factory_python | additional_links
+    factory_python -= {
+        'python-Django',  # prefer python-Django1
+    }
 
-results = []
-for f in concurrent.futures.as_completed(futures):
-    results.append(f.result())
+    futures = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_PROCS) as executor:
+        # remove packages not in tumbleweed
+        for package in backports_python - factory_python:
+            futures.append(executor.submit(rdelete, package, project))
 
-results = [x for x in results if x != 0]
+        # add packages not in yet
+        for package in factory_python - python_itself - backports_python:
+            futures.append(executor.submit(linkpac, package, project))
 
-sys.exit(len(results))
+        results = []
+        for f in concurrent.futures.as_completed(futures):
+            results.append(f.result())
+
+        results = [x for x in results if x != 0]
+
+        return(len(results))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Update the backports repo '
+                                     'with packages from openSUSE:Factory')
+    parser.add_argument('--obs-api', default='https://api.opensuse.org',
+                        help='The OpenBuildService API to use. Defaults to '
+                        '%(default)s')
+    parser.add_argument('--backports-project',
+                        default='devel:languages:python:backports',
+                        help='The OpenBuildService backportsproject. Defaults '
+                        'to %(default)s')
+    parser.add_argument('--factory-project',
+                        default='openSUSE:Factory',
+                        help='The OpenBuildService Factory project. Defaults '
+                        'to %(default)s')
+
+    args = parser.parse_args()
+    sys.exit(main(args))

--- a/backports_repo.py
+++ b/backports_repo.py
@@ -18,7 +18,6 @@ logging.basicConfig(format='%(levelname)s:%(funcName)s:%(message)s',
                     level=logging.DEBUG)
 log = logging.getLogger('backports_repo')
 
-MAX_PROCS = 5
 
 def _get_osc_config(config_file, config_section):
     """
@@ -109,7 +108,7 @@ def main(args):
     }
 
     futures = []
-    with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_PROCS) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.max_workers) as executor:
         # remove packages not in tumbleweed
         for package in backports_python - factory_python:
             futures.append(executor.submit(rdelete, package, project))
@@ -140,6 +139,9 @@ if __name__ == '__main__':
     parser.add_argument('--factory-project',
                         default='openSUSE:Factory',
                         help='The OpenBuildService Factory project. Defaults '
+                        'to %(default)s')
+    parser.add_argument('--max-workers', type=int,
+                        default=5, help='Number of workers. Defaults '
                         'to %(default)s')
 
     args = parser.parse_args()

--- a/backports_repo.py
+++ b/backports_repo.py
@@ -70,24 +70,22 @@ def linkpac(pkg, proj_source):
 
 
 def _get_additional_links_from_config():
-    additional_links = set()
-    additional_conf_file = os.path.join(appdirs.user_config_dir(),
-                                        'osc', 'backports_repo.json')
-    # Fall back to in-tree copy
-    if not os.path.exists(additional_conf_file):
-        additional_conf_file = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), 'backports_repo.json')
-
-    # extra packages we want there
-    if os.path.exists(additional_conf_file):
-        with io.open(additional_conf_file) as conf_f:
+    conf_file = os.path.join(appdirs.user_config_dir(),
+                             'osc', 'backports_repo.json')
+    conf_file_fallback = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), 'backports_repo.json')
+    for f in [conf_file, conf_file_fallback]:
+        if not os.path.exists(f):
+            continue
+        with io.open(f) as conf_f:
             obj = json.load(conf_f)
             if 'additional_links' not in obj:
                 raise KeyError(
                     '"additional_links" not found in configuration file %s' %
                     additional_conf_file)
-        additional_links = set(obj['additional_links'])
-    return additional_links
+        log.debug('Using additional links from {}'.format(f))
+        return set(obj['additional_links'])
+    return set()
 
 
 def main(args):


### PR DESCRIPTION
This improves readability and makes future changes easier. The
following changes are done:

- Use a main() method for the actual work done by the script
- Use argparse to make some parameters configurable
- Don't use global variables
- Move different parts to functions