### PR TITLE
backports_repo.json: Add librdkafka

### DIFF
--- a/backports_repo.json
+++ b/backports_repo.json
@@ -5,6 +5,7 @@
         "openstack-macros",
         "libsodium",
         "libcryptopp",
-        "redis"
+        "redis",
+        "librdkafka"
     ]
 }


### PR DESCRIPTION
This is needed to build python-confluent-kafka