### PR TITLE
Do not backport libxml2

### DIFF
--- a/backports_repo.json
+++ b/backports_repo.json
@@ -8,7 +8,6 @@
         "protobuf",
         "libsodium",
         "libcryptopp",
-        "libxml2",
         "redis",
         "librdkafka"
     ]


### PR DESCRIPTION
Libxml2 is provided by default by the OSS/updates repositories,
and should not be backported with python, as it might cause
version conflicts, with mismatching libxml2-devel for example.