### PR TITLE
Add jupyter-filesystem

### DIFF
--- a/backports_repo.json
+++ b/backports_repo.json
@@ -4,6 +4,7 @@
         "git",
         "grpc",
         "jupyter",
+        "jupyter-filesystem",        
         "libcryptopp",
         "libmaxminddb",
         "librdkafka",


### PR DESCRIPTION
My request in https://build.opensuse.org/project/show/devel:languages:python:backports#comment-1719854 was mainly for the jupyter macros in jupyter-filesystem.

jupyter-filesystem is one of those old-style link packages with a specfile jupyter-filesystem.spec in the jupyter package. Not sure if this is the right PR then.